### PR TITLE
Define method in sublcass itself

### DIFF
--- a/lib/draft_log/active_record_log_subscriber.rb
+++ b/lib/draft_log/active_record_log_subscriber.rb
@@ -30,5 +30,12 @@ module DraftLog
       Thread.current[:active_record_log_payload] ||= []
       Thread.current[:active_record_log_payload] << "  #{name}  #{sql}#{binds}"
     end
+
+    private
+
+      def type_casted_binds(binds, casted_binds)
+        casted_binds || ActiveRecord::Base.connection.type_casted_binds(binds)
+      end
+    
   end
 end


### PR DESCRIPTION
- method definition `type_casted_binds` varies from different rails version, hence defining in the subclass itself.
- Fixes #11 
